### PR TITLE
Compatibility with Gradle & AGP v7+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,5 +43,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
"implementation" substitutes "compile", as the later is deprecated